### PR TITLE
Add low-memory ESMFold2 inference option

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,48 @@ with open("1mht_pred.cif", "w") as f:
 
 > **AMD ROCm users:** use ROCm 6.4 with PyTorch 2.9 or newer.
 
+### Low-memory ESMFold2 inference
+
+ESMFold2 now releases its initial deterministic relative-position and
+token-bond pair encodings before the trunk. It recreates relative-position
+features for diffusion and retains them through the immediately following
+confidence calculation, while recreating token-bond features only for
+confidence. It also delays the returned distogram until after diffusion and
+confidence. These scheduling changes are always enabled and preserve tensor
+values and model math. Pair-feature recomputation uses the same BF16 CUDA
+autocast context as the original forward computation.
+
+Two additional memory-saving behaviors can be enabled together, either on
+`model.forward()` or through `ESMFold2InputBuilder.fold()`:
+
+```python
+result = ESMFold2InputBuilder().fold(
+    model,
+    spi,
+    low_memory_mode=True,
+)
+```
+
+`low_memory_mode=True` enables ESMC offload after LM feature extraction and
+confidence sample chunking with chunk size 1. Passing
+`offload_esmc_after_lm=False` explicitly disables offload even when the preset
+is enabled.
+
+- `offload_esmc_after_lm=True` moves the frozen ESMC backbone to CPU after its
+  hidden states have been projected into ESMFold2 pair features. A later call
+  restores it automatically. This saves resident GPU memory during the trunk,
+  diffusion, and confidence phases at the cost of CPU RAM and PCIe transfer
+  time between repeated calls.
+  FP8 ESMC backbones reject this option until CPU offload has been validated
+  for that precision mode.
+- `confidence_sample_chunk_size=1` evaluates confidence one diffusion sample at
+  a time instead of expanding the pair representation across every sample.
+  Larger values trade peak VRAM for throughput. The default `None` retains the
+  fully batched path. Chunking preserves output ordering and model math, though
+  changing a kernel's batch shape can introduce low-order floating-point
+  differences. Chunk outputs are written directly into their final
+  batch-major buffers, avoiding a second peak from concatenating all chunks.
+
 ### Running ESMFold2 Through the Biohub Platform
 
 Install the `esm` Python package

--- a/esm/models/esmfold2/model.py
+++ b/esm/models/esmfold2/model.py
@@ -515,6 +515,13 @@ class EsmFold2Model(HubPreTrainedModel):
       default to ``config.structure_head``; the sigma cap truncates the schedule.
     * ``msa_max_depth`` / ``msa_column_mask_rate``: inference-time MSA diversity,
       defaulting to ``config.msa_encoder`` when ``None``.
+    * ``low_memory_mode``: enable ESMC offload and confidence sample chunking
+      with chunk size ``1``. The default ``False`` preserves current behavior.
+    * ``offload_esmc_after_lm``: move ESMC to CPU after LM feature extraction;
+      it is restored automatically before a later call needs it. ``None`` uses
+      the ``low_memory_mode`` preset, while an explicit boolean overrides it.
+    * ``confidence_sample_chunk_size``: evaluate confidence for at most this
+      many diffusion samples at once. ``1`` minimizes confidence-head VRAM.
 
     Unknown keywords raise ``TypeError``; only the inference-irrelevant keys the
     featurizer emits (``_IGNORED_FEATURE_KEYS``) are accepted and dropped.
@@ -801,6 +808,99 @@ class EsmFold2Model(HubPreTrainedModel):
                 lm_mask_pct=lm_mask_pct,
             )
 
+    def _move_esmc_to(self, device: torch.device) -> None:
+        """Move the frozen LM backbone without changing its dtype or mode."""
+        if self.esmc is None:
+            return
+        parameter = next(self.esmc.parameters(), None)
+        if parameter is not None and parameter.device == device:
+            return
+        self.esmc.to(device=device)
+
+    def _compute_pair_encodings(
+        self,
+        *,
+        residue_index: Tensor,
+        asym_id: Tensor,
+        sym_id: Tensor,
+        entity_id: Tensor,
+        token_index: Tensor,
+        token_bonds: Tensor | None = None,
+        relative_position_encoding: Tensor | None = None,
+        use_amp: bool,
+    ) -> tuple[Tensor, Tensor | None]:
+        """Create missing static pair features with the forward path's AMP semantics."""
+        with torch.amp.autocast("cuda", enabled=use_amp, dtype=torch.bfloat16):
+            if relative_position_encoding is None:
+                relative_position_encoding = self.rel_pos(
+                    residue_index=residue_index,
+                    asym_id=asym_id,
+                    sym_id=sym_id,
+                    entity_id=entity_id,
+                    token_index=token_index,
+                )
+            token_bonds_encoding = (
+                self.token_bonds(token_bonds.float())
+                if token_bonds is not None
+                else None
+            )
+        return relative_position_encoding, token_bonds_encoding
+
+    def _run_confidence_head(
+        self,
+        *,
+        sample_chunk_size: int | None,
+        num_diffusion_samples: int,
+        x_pred: Tensor,
+        **kwargs: Any,
+    ) -> dict[str, Tensor]:
+        """Run confidence in sample chunks and restore batch-major ordering."""
+        if sample_chunk_size is None or sample_chunk_size >= num_diffusion_samples:
+            return self.confidence_head(
+                x_pred=x_pred, num_diffusion_samples=num_diffusion_samples, **kwargs
+            )
+        if sample_chunk_size < 1:
+            raise ValueError("confidence_sample_chunk_size must be at least 1")
+        batch_size = kwargs["s_inputs"].shape[0]
+        if x_pred.ndim == 3:
+            x_pred = x_pred.reshape(
+                batch_size, num_diffusion_samples, *x_pred.shape[1:]
+            )
+        elif x_pred.ndim != 4:
+            raise ValueError(
+                "chunked confidence requires sample_atom_coords shaped either "
+                "[batch * samples, atoms, 3] or [batch, samples, atoms, 3]"
+            )
+
+        outputs: dict[str, Tensor] = {}
+        for start in range(0, num_diffusion_samples, sample_chunk_size):
+            stop = min(start + sample_chunk_size, num_diffusion_samples)
+            chunk_samples = stop - start
+            chunk_output = self.confidence_head(
+                x_pred=x_pred[:, start:stop],
+                num_diffusion_samples=chunk_samples,
+                **kwargs,
+            )
+            for name in chunk_output:
+                chunk_value = chunk_output[name].reshape(
+                    batch_size, chunk_samples, *chunk_output[name].shape[1:]
+                )
+                if name not in outputs:
+                    outputs[name] = torch.empty(
+                        batch_size,
+                        num_diffusion_samples,
+                        *chunk_output[name].shape[1:],
+                        dtype=chunk_output[name].dtype,
+                        device=chunk_output[name].device,
+                    )
+                outputs[name][:, start:stop].copy_(chunk_value)
+                del chunk_value
+            del chunk_output
+        return {
+            name: value.reshape(batch_size * num_diffusion_samples, *value.shape[2:])
+            for name, value in outputs.items()
+        }
+
     def _discretized_dynamics(self) -> tuple[Tensor, Tensor]:
         delta = F.softplus(self.parcae_log_delta)
         a = torch.exp(-delta * torch.exp(self.parcae_log_a))
@@ -947,6 +1047,9 @@ class EsmFold2Model(HubPreTrainedModel):
         max_inference_sigma: float | None = 256.0,
         disto_cond: Tensor | None = None,
         disto_cond_mask: Tensor | None = None,
+        low_memory_mode: bool = False,
+        offload_esmc_after_lm: bool | None = None,
+        confidence_sample_chunk_size: int | None = None,
         **unused_features: Tensor,
     ) -> dict[str, Tensor]:
         unexpected = sorted(set(unused_features) - _IGNORED_FEATURE_KEYS)
@@ -975,7 +1078,25 @@ class EsmFold2Model(HubPreTrainedModel):
             if num_diffusion_samples is not None
             else self.config.num_diffusion_samples
         )
+        if offload_esmc_after_lm is None:
+            offload_esmc_after_lm = low_memory_mode
+        if low_memory_mode:
+            if confidence_sample_chunk_size is None:
+                confidence_sample_chunk_size = 1
         total_steps = max(1, n_loops + 1)
+        if (
+            confidence_sample_chunk_size is not None
+            and confidence_sample_chunk_size < 1
+        ):
+            raise ValueError("confidence_sample_chunk_size must be at least 1")
+        if offload_esmc_after_lm and self._esmc_fp8:
+            raise ValueError(
+                "offload_esmc_after_lm=True is not supported while the ESMC "
+                "backbone uses FP8"
+            )
+
+        if lm_hidden_states is None and input_ids is not None and self.esmc is not None:
+            self._move_esmc_to(input_ids.device)
 
         if res_type.dim() == 2:
             res_type_oh = F.one_hot(res_type.long(), num_classes=NUM_RES_TYPES).float()
@@ -1033,15 +1154,20 @@ class EsmFold2Model(HubPreTrainedModel):
                 x_inputs
             ).unsqueeze(1)
 
-            relative_position_encoding = self.rel_pos(
-                residue_index=residue_index,
-                asym_id=asym_id,
-                sym_id=sym_id,
-                entity_id=entity_id,
-                token_index=token_index,
+            relative_position_encoding, token_bonds_encoding = (
+                self._compute_pair_encodings(
+                    residue_index=residue_index,
+                    asym_id=asym_id,
+                    sym_id=sym_id,
+                    entity_id=entity_id,
+                    token_index=token_index,
+                    token_bonds=token_bonds,
+                    use_amp=use_amp,
+                )
             )
-            token_bonds_encoding = self.token_bonds(token_bonds.float())
+            assert token_bonds_encoding is not None
             z_init = z_init + relative_position_encoding + token_bonds_encoding
+            del relative_position_encoding, token_bonds_encoding
 
             if (
                 lm_hidden_states is None
@@ -1064,6 +1190,8 @@ class EsmFold2Model(HubPreTrainedModel):
             if lm_hidden_states is not None:
                 lm_z = self.language_model(lm_hidden_states.detach())
             del lm_hidden_states
+            if offload_esmc_after_lm and self.esmc is not None:
+                self._move_esmc_to(torch.device("cpu"))
 
             pair_mask = tok_mask[:, :, None].float() * tok_mask[:, None, :].float()
 
@@ -1117,7 +1245,15 @@ class EsmFold2Model(HubPreTrainedModel):
             z = self.parcae_coda(z, pair_attention_mask=pair_mask)
 
             z = z.float()
-        distogram_logits = self.distogram_head(z + z.transpose(-2, -3))
+
+        relative_position_encoding, _ = self._compute_pair_encodings(
+            residue_index=residue_index,
+            asym_id=asym_id,
+            sym_id=sym_id,
+            entity_id=entity_id,
+            token_index=token_index,
+            use_amp=use_amp,
+        )
 
         structure_output = self.structure_head.sample(
             z_trunk=z,
@@ -1147,23 +1283,42 @@ class EsmFold2Model(HubPreTrainedModel):
 
         sample_coords = structure_output["sample_atom_coords"]
         assert sample_coords is not None
-        output: dict[str, Tensor] = {"distogram_logits": distogram_logits}
-        output["sample_atom_coords"] = sample_coords
 
-        confidence_output = self.confidence_head(
+        relative_position_encoding, token_bonds_encoding = self._compute_pair_encodings(
+            residue_index=residue_index,
+            asym_id=asym_id,
+            sym_id=sym_id,
+            entity_id=entity_id,
+            token_index=token_index,
+            token_bonds=token_bonds,
+            relative_position_encoding=relative_position_encoding,
+            use_amp=use_amp,
+        )
+        assert token_bonds_encoding is not None
+        confidence_output = self._run_confidence_head(
+            sample_chunk_size=confidence_sample_chunk_size,
+            num_diffusion_samples=n_samples,
+            x_pred=sample_coords.detach(),
             s_inputs=x_inputs.detach(),
             z=z.detach().float(),
-            x_pred=sample_coords.detach(),
             distogram_atom_idx=disto_idx,
             token_attention_mask=tok_mask,
             atom_to_token=atom_to_token,
             atom_attention_mask=atm_mask,
             asym_id=asym_id,
             mol_type=mol_type,
-            num_diffusion_samples=n_samples,
             relative_position_encoding=relative_position_encoding.detach(),
             token_bonds_encoding=token_bonds_encoding.detach(),
         )
+        del relative_position_encoding, token_bonds_encoding
+
+        # Materialize the returned distogram only after diffusion and confidence
+        # have released their larger temporary pair representations.
+        distogram_logits = self.distogram_head(z + z.transpose(-2, -3))
+        output: dict[str, Tensor] = {
+            "distogram_logits": distogram_logits,
+            "sample_atom_coords": sample_coords,
+        }
         output.update(confidence_output)
         output["atom_pad_mask"] = (
             atm_mask.unsqueeze(0) if atm_mask.dim() == 1 else atm_mask

--- a/esm/models/esmfold2/processor.py
+++ b/esm/models/esmfold2/processor.py
@@ -343,6 +343,9 @@ class ESMFold2InputBuilder:
         msa_max_depth: int | None = 1024,
         msa_column_mask_rate: float = 0.1,
         msa_subsample_at_inference: bool | None = None,
+        low_memory_mode: bool = False,
+        offload_esmc_after_lm: bool | None = None,
+        confidence_sample_chunk_size: int | None = None,
         complex_id: str = "pred",
     ) -> MolecularComplexResult | list[MolecularComplexResult]:
         """Fold a structure end-to-end: encode → model → decode.
@@ -375,6 +378,17 @@ class ESMFold2InputBuilder:
             (shared across loops). Defaults to
             ``config.msa_encoder.column_mask_rate`` when ``None``. Only affects
             inputs that carry an MSA.
+        low_memory_mode : bool, optional
+            Enable ESMC CPU offload and confidence sample chunking with chunk
+            size 1. ``False`` preserves the default fully batched behavior.
+        offload_esmc_after_lm : bool, optional
+            Move the ESMC backbone to CPU after LM feature extraction. It is
+            restored automatically if a subsequent fold needs it. ``None``
+            uses the ``low_memory_mode`` preset; an explicit boolean overrides
+            that preset.
+        confidence_sample_chunk_size : int, optional
+            Maximum diffusion samples evaluated together by the confidence
+            head. ``None`` preserves the current fully batched behavior.
         complex_id : str
             Identifier assigned to the predicted MolecularComplex(es).
 
@@ -415,6 +429,9 @@ class ESMFold2InputBuilder:
                         num_diffusion_samples=num_diffusion_samples,
                         msa_max_depth=msa_max_depth,
                         msa_column_mask_rate=msa_column_mask_rate,
+                        low_memory_mode=low_memory_mode,
+                        offload_esmc_after_lm=offload_esmc_after_lm,
+                        confidence_sample_chunk_size=confidence_sample_chunk_size,
                         **sampler_kwargs,
                     )
 

--- a/tests/models/esmfold2_memory_test.py
+++ b/tests/models/esmfold2_memory_test.py
@@ -1,0 +1,390 @@
+"""Parity tests for opt-in ESMFold2 low-memory inference paths.
+
+The tests use tiny randomly initialized CPU models and never download weights.
+They cover the topology and sample-ordering contracts that are easy to break
+while reducing inference memory; the stored execution reference separately pins
+the default monomer forward bit-for-bit.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from esm.models.esmc import EsmcModel
+from esm.models.esmfold2 import layers as _layers
+from esm.models.esmfold2.protein_utils import prepare_protein_features
+
+
+@pytest.fixture(autouse=True)
+def _force_reference_attention(monkeypatch):
+    monkeypatch.setattr(_layers, "FLASH_ATTN_AVAILABLE", False)
+
+
+def _topology_features(chains: tuple[str, ...]) -> dict[str, torch.Tensor]:
+    """Protein-only forward features with chain identity set explicitly."""
+    features = prepare_protein_features("".join(chains))
+    length = sum(map(len, chains))
+    asym = torch.empty(1, length, dtype=torch.long)
+    residue = torch.empty(1, length, dtype=torch.long)
+    entity = torch.empty(1, length, dtype=torch.long)
+    sym = torch.empty(1, length, dtype=torch.long)
+    entity_for_sequence: dict[str, int] = {}
+    copies_per_entity: dict[int, int] = {}
+    offset = 0
+    for chain_id, sequence in enumerate(chains):
+        stop = offset + len(sequence)
+        entity_id = entity_for_sequence.setdefault(sequence, len(entity_for_sequence))
+        sym_id = copies_per_entity.get(entity_id, 0)
+        copies_per_entity[entity_id] = sym_id + 1
+        asym[:, offset:stop] = chain_id
+        residue[:, offset:stop] = torch.arange(len(sequence))
+        entity[:, offset:stop] = entity_id
+        sym[:, offset:stop] = sym_id
+        if offset:
+            features["token_bonds"][:, offset - 1, offset] = 0
+            features["token_bonds"][:, offset, offset - 1] = 0
+        offset = stop
+    features.update(asym_id=asym, residue_index=residue, entity_id=entity, sym_id=sym)
+    return features
+
+
+def _synthetic_lm_states(model, length: int, batch_size: int = 1) -> torch.Tensor:
+    torch.manual_seed(11)
+    return torch.randn(
+        batch_size, length, model.config.lm_num_layers + 1, model.config.lm_d_model
+    )
+
+
+def _repeat_batch(
+    features: dict[str, torch.Tensor], batch_size: int
+) -> dict[str, torch.Tensor]:
+    return {
+        name: value.expand(batch_size, *value.shape[1:]).clone()
+        for name, value in features.items()
+    }
+
+
+def _assert_forward_outputs_close(
+    baseline: dict[str, torch.Tensor], candidate: dict[str, torch.Tensor]
+) -> None:
+    assert baseline.keys() == candidate.keys()
+    for name in baseline:
+        if name in {
+            "sample_atom_coords",
+            "distogram_logits",
+            "atom_pad_mask",
+            "residue_index",
+            "entity_id",
+        }:
+            torch.testing.assert_close(baseline[name], candidate[name], atol=0, rtol=0)
+        else:
+            # Changing the confidence-head batch shape can select a different
+            # reduction order; observed CPU drift is below 4e-7 absolute.
+            torch.testing.assert_close(
+                baseline[name], candidate[name], atol=1e-6, rtol=1e-6
+            )
+
+
+@pytest.mark.parametrize(
+    "chains",
+    [(("ACDEFG",)), (("ACDEFG", "HIKLM")), (("ACDEFG", "ACDEFG"))],
+    ids=["monomer", "heteromer", "homomer"],
+)
+def test_confidence_sample_chunking_preserves_all_outputs(tiny_esmfold2, chains):
+    features = _topology_features(chains)
+    lm_states = _synthetic_lm_states(tiny_esmfold2, sum(map(len, chains)))
+    settings = dict(num_loops=1, num_sampling_steps=2, num_diffusion_samples=3)
+
+    torch.manual_seed(19)
+    baseline = tiny_esmfold2(**features, lm_hidden_states=lm_states.clone(), **settings)
+    torch.manual_seed(19)
+    chunked = tiny_esmfold2(
+        **features,
+        lm_hidden_states=lm_states.clone(),
+        confidence_sample_chunk_size=1,
+        **settings,
+    )
+
+    _assert_forward_outputs_close(baseline, chunked)
+
+
+def test_confidence_chunking_preserves_batch_sample_order_with_remainder(tiny_esmfold2):
+    features = _repeat_batch(_topology_features(("ACDEFG",)), batch_size=2)
+    lm_states = _synthetic_lm_states(tiny_esmfold2, 6, batch_size=2)
+    settings = dict(num_loops=1, num_sampling_steps=2, num_diffusion_samples=3)
+
+    torch.manual_seed(31)
+    baseline = tiny_esmfold2(**features, lm_hidden_states=lm_states.clone(), **settings)
+    torch.manual_seed(31)
+    chunked = tiny_esmfold2(
+        **features,
+        lm_hidden_states=lm_states.clone(),
+        confidence_sample_chunk_size=2,
+        **settings,
+    )
+
+    _assert_forward_outputs_close(baseline, chunked)
+
+
+def test_pair_encodings_are_recomputed_at_their_use_sites(tiny_esmfold2):
+    features = _topology_features(("ACDEFG",))
+    lm_states = _synthetic_lm_states(tiny_esmfold2, 6)
+    calls = {"relative": 0, "bonds": 0}
+    handles = [
+        tiny_esmfold2.rel_pos.register_forward_hook(
+            lambda *_: calls.__setitem__("relative", calls["relative"] + 1)
+        ),
+        tiny_esmfold2.token_bonds.register_forward_hook(
+            lambda *_: calls.__setitem__("bonds", calls["bonds"] + 1)
+        ),
+    ]
+    try:
+        torch.manual_seed(3)
+        tiny_esmfold2(
+            **features,
+            lm_hidden_states=lm_states,
+            num_loops=1,
+            num_sampling_steps=2,
+            num_diffusion_samples=1,
+        )
+    finally:
+        for handle in handles:
+            handle.remove()
+
+    assert calls == {"relative": 2, "bonds": 2}
+
+
+def test_recomputed_pair_encodings_match_cached_upstream_output(
+    tiny_esmfold2, monkeypatch
+):
+    features = _topology_features(("ACDEFG",))
+    lm_states = _synthetic_lm_states(tiny_esmfold2, 6)
+    settings = dict(num_loops=1, num_sampling_steps=2, num_diffusion_samples=1)
+
+    torch.manual_seed(43)
+    recomputed = tiny_esmfold2(
+        **features, lm_hidden_states=lm_states.clone(), **settings
+    )
+
+    real_compute_pair_encodings = tiny_esmfold2._compute_pair_encodings
+    cached_relative = None
+    cached_bonds = None
+
+    def use_upstream_cached_pair_encodings(*, token_bonds=None, **kwargs):
+        nonlocal cached_relative, cached_bonds
+        if cached_relative is None:
+            cached_relative, cached_bonds = real_compute_pair_encodings(
+                token_bonds=features["token_bonds"], **kwargs
+            )
+        return cached_relative, cached_bonds if token_bonds is not None else None
+
+    monkeypatch.setattr(
+        tiny_esmfold2, "_compute_pair_encodings", use_upstream_cached_pair_encodings
+    )
+    torch.manual_seed(43)
+    upstream_semantics = tiny_esmfold2(
+        **features, lm_hidden_states=lm_states.clone(), **settings
+    )
+
+    _assert_forward_outputs_close(upstream_semantics, recomputed)
+
+
+def test_distogram_is_materialized_after_diffusion_and_confidence(
+    tiny_esmfold2, monkeypatch
+):
+    features = _topology_features(("ACDEFG",))
+    lm_states = _synthetic_lm_states(tiny_esmfold2, 6)
+    order: list[str] = []
+    real_sample = tiny_esmfold2.structure_head.sample
+
+    def record_sample(**kwargs):
+        order.append("diffusion")
+        return real_sample(**kwargs)
+
+    monkeypatch.setattr(tiny_esmfold2.structure_head, "sample", record_sample)
+    handles = [
+        tiny_esmfold2.confidence_head.register_forward_hook(
+            lambda *_: order.append("confidence")
+        ),
+        tiny_esmfold2.distogram_head.register_forward_hook(
+            lambda *_: order.append("distogram")
+        ),
+    ]
+    try:
+        torch.manual_seed(5)
+        tiny_esmfold2(
+            **features,
+            lm_hidden_states=lm_states,
+            num_loops=1,
+            num_sampling_steps=2,
+            num_diffusion_samples=1,
+        )
+    finally:
+        for handle in handles:
+            handle.remove()
+
+    assert order[-3:] == ["diffusion", "confidence", "distogram"]
+
+
+@pytest.mark.parametrize(
+    "chains",
+    [("ACDEFG",), ("ACDEFG", "HIKLM"), ("ACDEFG", "ACDEFG")],
+    ids=["monomer", "heteromer", "homomer"],
+)
+def test_esmc_offload_option_preserves_output_and_requests_cpu(
+    tiny_esmfold2, tiny_esmc_config, monkeypatch, chains
+):
+    features = _topology_features(chains)
+    torch.manual_seed(0)
+    tiny_esmfold2.esmc = EsmcModel(tiny_esmc_config).eval()
+    requested_devices: list[torch.device] = []
+    real_move = tiny_esmfold2._move_esmc_to
+
+    def record_move(device):
+        requested_devices.append(torch.device(device))
+        real_move(torch.device(device))
+
+    monkeypatch.setattr(tiny_esmfold2, "_move_esmc_to", record_move)
+
+    torch.manual_seed(23)
+    baseline = tiny_esmfold2(
+        **features, num_loops=1, num_sampling_steps=2, num_diffusion_samples=1
+    )
+    torch.manual_seed(23)
+    offloaded = tiny_esmfold2(
+        **features,
+        offload_esmc_after_lm=True,
+        num_loops=1,
+        num_sampling_steps=2,
+        num_diffusion_samples=1,
+    )
+
+    assert torch.device("cpu") in requested_devices
+    for name in baseline:
+        torch.testing.assert_close(baseline[name], offloaded[name], atol=0, rtol=0)
+
+
+def test_esmc_offload_rejects_fp8(tiny_esmfold2):
+    features = _topology_features(("ACDEFG",))
+    lm_states = _synthetic_lm_states(tiny_esmfold2, 6)
+    tiny_esmfold2._esmc_fp8 = True
+
+    with pytest.raises(ValueError, match="not supported.*FP8"):
+        tiny_esmfold2(
+            **features,
+            lm_hidden_states=lm_states,
+            offload_esmc_after_lm=True,
+            num_loops=1,
+            num_sampling_steps=2,
+            num_diffusion_samples=1,
+        )
+
+
+def test_explicit_offload_false_overrides_low_memory_preset(tiny_esmfold2, monkeypatch):
+    features = _topology_features(("ACDEFG",))
+    lm_states = _synthetic_lm_states(tiny_esmfold2, 6)
+    tiny_esmfold2.esmc = torch.nn.Linear(1, 1, bias=False).eval()
+    requested_devices: list[torch.device] = []
+    monkeypatch.setattr(
+        tiny_esmfold2,
+        "_move_esmc_to",
+        lambda device: requested_devices.append(torch.device(device)),
+    )
+
+    torch.manual_seed(37)
+    tiny_esmfold2(
+        **features,
+        lm_hidden_states=lm_states,
+        low_memory_mode=True,
+        offload_esmc_after_lm=False,
+        num_loops=1,
+        num_sampling_steps=2,
+        num_diffusion_samples=1,
+    )
+
+    assert requested_devices == []
+
+
+def test_low_memory_mode_matches_explicit_combined_options(tiny_esmfold2, monkeypatch):
+    features = _topology_features(("ACDEFG", "ACDEFG"))
+    lm_states = _synthetic_lm_states(tiny_esmfold2, 12)
+    tiny_esmfold2.esmc = torch.nn.Linear(1, 1, bias=False).eval()
+    requested_devices: list[torch.device] = []
+    confidence_chunks: list[int | None] = []
+    real_move = tiny_esmfold2._move_esmc_to
+    real_confidence = tiny_esmfold2._run_confidence_head
+
+    def record_move(device):
+        requested_devices.append(torch.device(device))
+        real_move(torch.device(device))
+
+    def record_confidence(*, sample_chunk_size, **kwargs):
+        confidence_chunks.append(sample_chunk_size)
+        return real_confidence(sample_chunk_size=sample_chunk_size, **kwargs)
+
+    monkeypatch.setattr(tiny_esmfold2, "_move_esmc_to", record_move)
+    monkeypatch.setattr(tiny_esmfold2, "_run_confidence_head", record_confidence)
+    settings = dict(num_loops=1, num_sampling_steps=2, num_diffusion_samples=3)
+
+    torch.manual_seed(29)
+    explicit = tiny_esmfold2(
+        **features,
+        lm_hidden_states=lm_states.clone(),
+        offload_esmc_after_lm=True,
+        confidence_sample_chunk_size=1,
+        **settings,
+    )
+    torch.manual_seed(29)
+    umbrella = tiny_esmfold2(
+        **features, lm_hidden_states=lm_states.clone(), low_memory_mode=True, **settings
+    )
+
+    assert requested_devices == [torch.device("cpu"), torch.device("cpu")]
+    assert confidence_chunks == [1, 1]
+    for name in explicit:
+        torch.testing.assert_close(explicit[name], umbrella[name], atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_cuda_recomputed_pair_encodings_preserve_autocast_and_default_output(
+    tiny_esmfold2,
+):
+    model = tiny_esmfold2.cuda().eval()
+    features = {
+        name: value.cuda() for name, value in _topology_features(("ACDEFG",)).items()
+    }
+    lm_states = _synthetic_lm_states(model, 6).cuda()
+    settings = dict(num_loops=1, num_sampling_steps=2, num_diffusion_samples=1)
+    observations: list[tuple[str, torch.Tensor, bool]] = []
+
+    def record_pair_output(name):
+        def hook(_module, _args, output):
+            observations.append(
+                (name, output.detach().clone(), torch.is_autocast_enabled("cuda"))
+            )
+
+        return hook
+
+    handles = [
+        model.rel_pos.register_forward_hook(record_pair_output("relative")),
+        model.token_bonds.register_forward_hook(record_pair_output("bonds")),
+    ]
+    torch.manual_seed(41)
+    model(**features, lm_hidden_states=lm_states, **settings)
+    for handle in handles:
+        handle.remove()
+
+    assert [name for name, _, _ in observations] == [
+        "relative",
+        "bonds",
+        "relative",
+        "bonds",
+    ]
+    assert all(value.dtype == torch.bfloat16 for _, value, _ in observations)
+    assert all(autocast_enabled for _, _, autocast_enabled in observations)
+    relative_outputs = [value for name, value, _ in observations if name == "relative"]
+    bond_outputs = [value for name, value, _ in observations if name == "bonds"]
+    for recomputed in relative_outputs[1:]:
+        torch.testing.assert_close(relative_outputs[0], recomputed, atol=0, rtol=0)
+    torch.testing.assert_close(bond_outputs[0], bond_outputs[1], atol=0, rtol=0)

--- a/tools/benchmark_esmfold2_inference.py
+++ b/tools/benchmark_esmfold2_inference.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Measure ESMFold2 inference peak VRAM and wall time for one low-memory mode.
+
+Run one variant per fresh process so CUDA allocator state and model placement do
+not leak across measurements. The script intentionally performs no MSA search;
+callers that supply precomputed MSA features should prepare them once and reuse
+the same feature artifact for every variant. One untimed warm-up is used by
+default; pass ``--warmup 0`` when cold-start latency is the quantity of interest.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from esm.models.esmc import kernels as esmc_kernels
+from esm.models.esmfold2 import ESMFold2InputBuilder, EsmFold2Model
+from esm.models.esmfold2 import layers as esmfold2_layers
+from esm.models.esmfold2.output import build_molecular_complex_from_features
+from esm.models.esmfold2.types import ProteinInput, StructurePredictionInput
+
+VARIANTS: dict[str, dict[str, Any]] = {
+    "default": {},
+    "esmc_offload": {"offload_esmc_after_lm": True},
+    "confidence_chunk_1": {"confidence_sample_chunk_size": 1},
+    "combined": {"low_memory_mode": True},
+}
+
+
+def parse_fasta(path: Path) -> list[tuple[str, str]]:
+    records: list[tuple[str, list[str]]] = []
+    name: str | None = None
+    sequence: list[str] = []
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.startswith(">"):
+            if name is not None:
+                records.append((name, sequence))
+            name = line[1:].strip() or f"chain_{len(records) + 1}"
+            sequence = []
+        else:
+            if name is None:
+                raise ValueError("FASTA sequence appears before its header")
+            sequence.append(line.upper())
+    if name is not None:
+        records.append((name, sequence))
+    parsed = [(name, "".join(chunks)) for name, chunks in records]
+    if not parsed or any(not sequence for _, sequence in parsed):
+        raise ValueError(f"no non-empty FASTA records found in {path}")
+    return parsed
+
+
+def synchronize() -> None:
+    torch.cuda.synchronize()
+
+
+def output_signature(
+    output: dict[str, torch.Tensor], asym_id: torch.Tensor
+) -> dict[str, float]:
+    """Small parity and confidence signature for the benchmark result JSON."""
+    signature: dict[str, float] = {}
+    for name in ("complex_plddt", "complex_iplddt", "ptm", "iptm"):
+        value = output.get(name)
+        if value is not None:
+            signature[f"{name}_mean"] = float(value.float().mean().cpu())
+    plddt = output["plddt"][0].float()
+    signature.update(
+        plddt_sample0_mean=float(plddt.mean().cpu()),
+        plddt_sample0_min=float(plddt.min().cpu()),
+        plddt_sample0_median=float(plddt.median().cpu()),
+        plddt_sample0_max=float(plddt.max().cpu()),
+    )
+    for chain_id in asym_id.unique(sorted=True):
+        chain_plddt = plddt[asym_id == chain_id]
+        signature[f"plddt_sample0_chain_{int(chain_id)}_mean"] = float(
+            chain_plddt.mean().cpu()
+        )
+    signature["coords_l2"] = float(
+        output["sample_atom_coords"].float().square().sum().sqrt().cpu()
+    )
+    signature["distogram_sum"] = float(output["distogram_logits"].float().sum().cpu())
+    return signature
+
+
+def run(args: argparse.Namespace) -> dict[str, Any]:
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required for a peak-VRAM benchmark")
+    backend_availability = {
+        "esmc_xformers": esmc_kernels.XFORMERS_INSTALLED,
+        "esmc_flash_attention": esmc_kernels.FLASH_ATTN_INSTALLED,
+        "esmc_flash_rotary": esmc_kernels.FLASH_ATTN_ROTARY_INSTALLED,
+        "esmfold2_flash_attention": esmfold2_layers.FLASH_ATTN_AVAILABLE,
+    }
+    print(
+        "ESMFold2 benchmark backend availability: "
+        + json.dumps(backend_availability, sort_keys=True),
+        flush=True,
+    )
+    records = parse_fasta(args.fasta)
+    structure_input = StructurePredictionInput(
+        sequences=[
+            ProteinInput(id=name.split()[0], sequence=sequence)
+            for name, sequence in records
+        ]
+    )
+
+    model = (
+        EsmFold2Model.from_pretrained(args.model, esmc_precision=args.esmc_precision)
+        .cuda()
+        .eval()
+    )
+    model.set_chunk_size(None if args.pair_chunk_size == 0 else args.pair_chunk_size)
+    builder = ESMFold2InputBuilder()
+    features, chain_infos = builder.prepare_input(
+        structure_input, seed=args.seed, device=model.device
+    )
+    forward_kwargs = {
+        "num_loops": args.num_loops,
+        "num_sampling_steps": args.num_sampling_steps,
+        "num_diffusion_samples": args.num_diffusion_samples,
+        **VARIANTS[args.variant],
+    }
+
+    for warmup_index in range(args.warmup):
+        torch.manual_seed(args.seed + warmup_index)
+        with torch.inference_mode():
+            model(**features, **forward_kwargs)
+        synchronize()
+
+    torch.manual_seed(args.seed)
+    torch.cuda.empty_cache()
+    synchronize()
+    allocated_before = torch.cuda.memory_allocated()
+    reserved_before = torch.cuda.memory_reserved()
+    torch.cuda.reset_peak_memory_stats()
+    start = time.perf_counter()
+    with torch.inference_mode():
+        output = model(**features, **forward_kwargs)
+    synchronize()
+    runtime_seconds = time.perf_counter() - start
+
+    if args.structure_output is not None:
+        args.structure_output.parent.mkdir(parents=True, exist_ok=True)
+        complex_sample = build_molecular_complex_from_features(
+            coords=output["sample_atom_coords"][0],
+            plddt=output["plddt"][0],
+            atom_mask=features["atom_attention_mask"][0],
+            ref_element=features["ref_element"][0],
+            ref_atom_name_chars=features["ref_atom_name_chars"][0],
+            chain_infos=chain_infos,
+            complex_id=f"{args.fasta.stem}_sample_0",
+        )
+        args.structure_output.write_text(complex_sample.to_mmcif())
+
+    device = torch.cuda.current_device()
+    return {
+        "variant": args.variant,
+        "model": args.model,
+        "esmc_precision": args.esmc_precision,
+        "chain_count": len(records),
+        "chain_lengths": [len(sequence) for _, sequence in records],
+        "total_tokens": sum(len(sequence) for _, sequence in records),
+        "num_loops": args.num_loops,
+        "num_sampling_steps": args.num_sampling_steps,
+        "num_diffusion_samples": args.num_diffusion_samples,
+        "pair_chunk_size": None if args.pair_chunk_size == 0 else args.pair_chunk_size,
+        "warmup": args.warmup,
+        "seed": args.seed,
+        "torch_version": torch.__version__,
+        "cuda_runtime_version": torch.version.cuda,
+        "backend_availability": backend_availability,
+        "gpu": torch.cuda.get_device_name(device),
+        "gpu_total_bytes": torch.cuda.get_device_properties(device).total_memory,
+        "allocated_before_bytes": allocated_before,
+        "reserved_before_bytes": reserved_before,
+        "peak_allocated_bytes": torch.cuda.max_memory_allocated(),
+        "peak_reserved_bytes": torch.cuda.max_memory_reserved(),
+        "allocated_after_bytes": torch.cuda.memory_allocated(),
+        "runtime_seconds": runtime_seconds,
+        "output_signature": output_signature(output, features["asym_id"][0]),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("fasta", type=Path)
+    parser.add_argument("--model", default="biohub/ESMFold2")
+    parser.add_argument("--variant", choices=VARIANTS, default="default")
+    parser.add_argument("--esmc-precision", default="bf16")
+    parser.add_argument("--num-loops", type=int, default=3)
+    parser.add_argument("--num-sampling-steps", type=int, default=50)
+    parser.add_argument("--num-diffusion-samples", type=int, default=4)
+    parser.add_argument("--pair-chunk-size", type=int, default=64)
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=1,
+        help="number of untimed warm-up iterations (default: 1)",
+    )
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument(
+        "--structure-output",
+        type=Path,
+        help=(
+            "optional sample-0 mmCIF output; per-residue pLDDT is stored in "
+            "the B-factor column"
+        ),
+    )
+    args = parser.parse_args()
+
+    result = run(args)
+    rendered = json.dumps(result, indent=2, sort_keys=True)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n")
+    print(rendered, flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Hi there, thanks for the very nice model, this PR adds a low-memory option for inference and some small general memory related tweaks:

* Always enabled:
   * Shortens the lifetime of large static pair encodings by freeing them before the trunk and recomputing them when needed later
   * Defers distogram materialization until immediately before output assembly

* Opt-in `low_memory_mode=True`, enabling:

  * ESMC CPU offload after LM feature extraction
  * Confidence evaluation in sample chunks of 1
 

I benchmarked it and saw improvements:
<img width="2900" height="2360" alt="image" src="https://github.com/user-attachments/assets/76333d74-0e75-44e8-b12d-1609d87c12eb" />

<img width="2900" height="2360" alt="image" src="https://github.com/user-attachments/assets/0f6d88c4-7f0d-4280-a9c4-8647da9b13fd" />


Low-memory execution is inspired by OpenFold3's `low_mem`  confidence handling and Chai-1's transient CPU/GPU component offloading.

Let me know if there is something you'd like to be changed. 