### PR TITLE
Make v3.4.0 publishable to PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,24 +64,17 @@ First, install `esm` from PyPI:
 pip install esm
 ```
 
-Then use the following code to run ESMC using the Transformers library via Hugging Face:
+Then use the following code to run ESMC using weights from Hugging Face:
 
 ```python
 import torch
-from transformers import AutoModelForMaskedLM, AutoTokenizer
-from huggingface_hub import login
-
-# login with your Hugging Face credentials
-login()
+from esm.models.esmc import EsmcForMaskedLM, EsmcTokenizer
 
 # example GFP sequence
 sequences = ["MSKGEELFTGVVPILVELDGDVNGHKFSVSGEGEGDATYGKLTLKFICTTGKLPVPWPTLVTTFSYGVQCFSRYPDHMKQHDFFKSAMPEGYVQERTIFFKDDGNYKTRAEVKFEGDTLVNRIELKGIDFKEDGNILGHKLEYNYNSHNVYIMADKQKNGIKVNFKIRHNIEDGSVQLADHYQQNTPIGDGPVLLPDNHYLSTQSALSKDPNEKRDHMVLLEFVTAAGITHGMDELYK"]
 
-model = AutoModelForMaskedLM.from_pretrained(
-    "biohub/ESMC-6B",
-    device_map="auto",
-).eval()
-tokenizer = AutoTokenizer.from_pretrained("biohub/ESMC-6B")
+model = EsmcForMaskedLM.from_pretrained("biohub/ESMC-6B", device="cuda").eval()
+tokenizer = EsmcTokenizer()
 
 inputs = tokenizer(sequences, return_tensors="pt", padding=True)
 inputs = {k: v.to(model.device) for k, v in inputs.items()}
@@ -153,17 +146,17 @@ First, install `esm` from PyPI:
 pip install esm
 ```
 
-Then use the following code to set up an ESMC SAE using the Transformers library via Hugging Face:
+Then use the following code to set up an ESMC SAE using weights from Hugging Face:
 
 ```python
 import torch
-from transformers import AutoModel, AutoTokenizer
+from esm.models.esmc import EsmcForMaskedLM, EsmcSaeModel, EsmcTokenizer
 
 sequence = "MGSNKSKPKDASQRRRSLEPAENVHGAGGGAFPASQTPSKPASADGHRGPSAAFAPAAAEPKLFGGFNSSDTVTSPQRAGPLAGGVTTFVALYDYESRTETDLSFKKGERLQIVNNTEGDWWLAHSLSTGQTGYIPSNYVAPSDSIQAEEWYFGKITRRESERLLLNAENPRGTFLVRESETTKGAYCLSVSDFDNAKGLNVKHYKIRKLDSGGFYITSRTQFNSLQQLVAYYSKHADGLCHRLTTVCPTSKPQTQGLAKDAWEIPRESLRLEVKLGQGCFGEVWMGTWNGTTRVAIKTLKPGTMSPEAFLQEAQVMKKLRHEKLVQLYAVVSEEPIYIVTEYMSKGSLLDFLKGETGKYLRLPQLVDMAAQIASGMAYVERMNYVHRDLRAANILVGENLVCKVADFGLARLIEDNEYTARQGAKFPIKWTAPEAALYGRFTIKSDVWSFGILLTELTTKGRVPYPGMVNREVLDQVERGYRMPCPPECPESLHDLMCQCWRKEPEERPTFEYLQAFLEDYFTSTEPQYQPGENL"
 
-model = AutoModel.from_pretrained("biohub/ESMC-6B", device_map="auto").eval()
-tokenizer = AutoTokenizer.from_pretrained("biohub/ESMC-6B")
-sae = AutoModel.from_pretrained(
+model = EsmcForMaskedLM.from_pretrained("biohub/ESMC-6B", device="cuda").eval()
+tokenizer = EsmcTokenizer()
+sae = EsmcSaeModel.from_pretrained(
     "biohub/ESMC-6B-sae-k64-codebook16384",
     allow_patterns=["config.json", "layer_30.safetensors", "layer_60.safetensors"],
     device=model.device,
@@ -177,8 +170,8 @@ inputs = {k: v.to(model.device) for k, v in inputs.items()}
 with torch.inference_mode():
     output = model(**inputs)
 
-output["sae_outputs"]["layer60"]  # sparse.coo tensor
-print(output["sae_outputs"]["layer60"].shape)
+output.sae_outputs["layer60"]  # sparse.coo tensor
+print(output.sae_outputs["layer60"].shape)
 
 ```
 ### Running SAEs Through The Biohub Platform
@@ -204,18 +197,18 @@ First, install `esm` from PyPI:
 pip install esm
 ```
 
-Then use the following code to run ESMFold2 locally using the Transformers library via Hugging Face:
+Then use the following code to run ESMFold2 locally using weights from Hugging Face:
 
 ```python
 from esm.models.esmfold2 import (
     DNAInput,
     ESMFold2InputBuilder,
+    EsmFold2Model,
     LigandInput,
     Modification,
     ProteinInput,
     StructurePredictionInput,
 )
-from transformers.models.esmfold2.modeling_esmfold2 import ESMFold2Model
 
 HHAI_SEQ = (
     "MIEIKDKQLTGLRFIDLFAGLGGFRLALESCGAECVYSNEWDKYAQEVYEMNFGEKPEGDITQVNEKTIPDH"
@@ -225,7 +218,7 @@ HHAI_SEQ = (
     "YKVHPSTSQAYKQFGNSVVINVLQYIAYNIGSSLNFKPY"
 )
 
-model = ESMFold2Model.from_pretrained("biohub/ESMFold2").cuda().eval()
+model = EsmFold2Model.from_pretrained("biohub/ESMFold2", device="cuda").eval()
 
 spi = StructurePredictionInput(
     sequences=[

--- a/cookbook/tutorials/binder_design.py
+++ b/cookbook/tutorials/binder_design.py
@@ -30,25 +30,8 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 import torch.optim as optim
-from transformers.models.esmc.modeling_esmc import ESMCForMaskedLM
-from transformers.models.esmc.tokenization_esmc import ESMCTokenizer
-from transformers.models.esmfold2.modeling_esmfold2_common import (
-    BACKEND_CUEQ,
-    BACKEND_FUSED,
-    CUE_AVAILABLE,
-    TRITON_KERNELS_AVAILABLE,
-    PairUpdateBlock,
-)
-from transformers.models.esmfold2.modeling_esmfold2_common import (
-    _seed_context as seed_context,
-)
-from transformers.models.esmfold2.modeling_esmfold2_experimental import (
-    ESMFold2ExperimentalModel,
-)
-from transformers.models.esmfold2.modeling_esmfold2_experimental import (
-    MSAEncoder as ESMFold2MSAEncoder,
-)
 
+from esm.models.esmc import EsmcForMaskedLM, EsmcTokenizer
 from esm.models.esmfold2 import (
     ELEMENT_NUMBER_TO_SYMBOL,
     ProteinInput,
@@ -62,6 +45,16 @@ from esm.models.esmfold2.constants import (
     PROTEIN_3TO1,
     RES_TYPE_TO_CCD,
 )
+from esm.models.esmfold2.experimental import EsmFold2ExperimentalModel
+from esm.models.esmfold2.experimental import MSAEncoder as EsmFold2MSAEncoder
+from esm.models.esmfold2.layers import (
+    BACKEND_CUEQ,
+    BACKEND_FUSED,
+    CUE_AVAILABLE,
+    TRITON_KERNELS_AVAILABLE,
+    PairUpdateBlock,
+)
+from esm.models.esmfold2.layers import _seed_context as seed_context
 from esm.utils.structure.mmcif_parsing import PLDDT_B_FACTOR_SCALE
 from esm.utils.structure.protein_chain import ProteinChain
 from esm.utils.structure.protein_complex import ProteinComplex
@@ -663,7 +656,7 @@ def prepare_esmfold2_tensors(
 
 
 def fold_and_get_distogram(
-    model: ESMFold2ExperimentalModel,
+    model: EsmFold2ExperimentalModel,
     target_seq: str,
     target_one_hot: torch.Tensor,
     design: torch.Tensor,
@@ -829,7 +822,7 @@ def _folding_trunk_to_lm_aa_vocab_matrix(device: torch.device) -> torch.Tensor:
     three_to_one_map = {v: k for k, v in PROTEIN_1TO3.items()}
     ft_aas = [three_to_one_map[tok_3letter] for tok_3letter in TOKENS[2:22]]
 
-    lm_vocab = sorted(ESMCTokenizer().vocab.items(), key=lambda x: x[1])
+    lm_vocab = sorted(EsmcTokenizer().vocab.items(), key=lambda x: x[1])
     lm_aas = [lm_vocab[i][0] for i in range(4, 24)]
 
     ft_to_lm_aa_matrix = torch.zeros(20, 20)
@@ -851,7 +844,7 @@ def _straight_through(discrete: torch.Tensor, continuous: torch.Tensor) -> torch
 
 
 def compute_esmc_pseudoperplexity_nll(
-    esmc_model: ESMCForMaskedLM,
+    esmc_model: EsmcForMaskedLM,
     binder_design: torch.Tensor,
     score_mask: torch.Tensor,
     batch_size: int = 4,
@@ -871,7 +864,7 @@ def compute_esmc_pseudoperplexity_nll(
         dtype=model_dtype,
         device=device,
     )
-    tokenizer = ESMCTokenizer()
+    tokenizer = EsmcTokenizer()
     input_ids[:, 0, tokenizer.cls_token_id] = 1  # pyright: ignore
     input_ids[:, -1, tokenizer.eos_token_id] = 1  # pyright: ignore
     input_ids[:, 1:-1, 4:24] = input_esm.to(model_dtype)
@@ -964,9 +957,9 @@ def normalized_gradient_tensor(
 
 
 def design_binder(
-    inversion_models: dict[str, ESMFold2ExperimentalModel],
-    hf_critic_models: dict[str, ESMFold2ExperimentalModel],
-    esmc_model: ESMCForMaskedLM,
+    inversion_models: dict[str, EsmFold2ExperimentalModel],
+    hf_critic_models: dict[str, EsmFold2ExperimentalModel],
+    esmc_model: EsmcForMaskedLM,
     scaling_critic_names: list[str] | None,
     target_name: str,
     target_sequence: str | None,
@@ -1153,7 +1146,7 @@ def design_binder(
 
     def score_critic(
         critic_name: str,
-        critic_model: ESMFold2ExperimentalModel,
+        critic_model: EsmFold2ExperimentalModel,
         batch_idx: int,
         is_scaling_critic: bool,
     ) -> None:
@@ -1235,7 +1228,7 @@ def _load_hf_model(
     """Loads ESMFold2 from huggingface. Will cache ESMC by checkpoint ID among
     all non-scaling checkpoints, to save on VRAM and load time."""
     repo_id = f"biohub/{critic_name}"
-    model = ESMFold2ExperimentalModel.from_pretrained(repo_id, load_esmc=not cache_esmc)
+    model = EsmFold2ExperimentalModel.from_pretrained(repo_id, load_esmc=not cache_esmc)
     if cache_esmc:
         esmc_id = model.config.esmc_id
         if esmc_id not in _ESMC_CACHE:
@@ -1258,7 +1251,7 @@ def _apply_torch_compile(model: torch.nn.Module) -> None:
     torch._dynamo.config.cache_size_limit = 512
     torch._dynamo.config.accumulated_cache_size_limit = 512
 
-    compile_targets = (ESMFold2MSAEncoder, PairUpdateBlock)
+    compile_targets = (EsmFold2MSAEncoder, PairUpdateBlock)
 
     def _maybe_compile_module(module: torch.nn.Module) -> None:
         if not isinstance(module, compile_targets):
@@ -1307,8 +1300,8 @@ class ESMFold2Design:
                 name, lm_dropout=0.25, cache_esmc=True, device="cuda"
             )
 
-        self.esmc_model = ESMCForMaskedLM.from_pretrained(
-            self.lm_name, torch_dtype=torch.float32
+        self.esmc_model = EsmcForMaskedLM.from_pretrained(
+            self.lm_name, dtype=torch.float32
         )
         if REUSE_ESMC:
             reusable_esmc_model = self.inversion_models["ESMFold2-Experimental-Fast"]

--- a/cookbook/tutorials/esmc_finetune.ipynb
+++ b/cookbook/tutorials/esmc_finetune.ipynb
@@ -49,7 +49,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from transformers import AutoTokenizer, ESMCForSequenceClassification"
+    "from esm.models.esmc import EsmcForSequenceClassification, EsmcTokenizer"
    ]
   },
   {
@@ -289,7 +289,7 @@
    "source": [
     "## The sequence classification model\n",
     "\n",
-    "`ESMCForSequenceClassification` wraps the pretrained ESMC encoder with a small classification head:\n",
+    "`EsmcForSequenceClassification` wraps the pretrained ESMC encoder with a small classification head:\n",
     "\n",
     "1. **ESMC backbone** — produces a per-token hidden state of shape `(batch, seq_len, d_model)`.\n",
     "2. **`<cls>` pooling** — the head takes the hidden state at position 0 (the `<cls>` token prepended by the tokenizer) as the sequence-level representation.\n",
@@ -309,9 +309,9 @@
    "source": [
     "MODEL_PATH = \"biohub/ESMC-300M\"\n",
     "\n",
-    "tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH)\n",
-    "model = ESMCForSequenceClassification.from_pretrained(\n",
-    "    MODEL_PATH, num_labels=len(ec1_classes), device_map=\"auto\"\n",
+    "tokenizer = EsmcTokenizer()\n",
+    "model = EsmcForSequenceClassification.from_pretrained(\n",
+    "    MODEL_PATH, num_labels=len(ec1_classes), device=\"cuda\"\n",
     ")"
    ]
   },

--- a/esm/models/esmc/kernels.py
+++ b/esm/models/esmc/kernels.py
@@ -80,8 +80,8 @@ if not XFORMERS_INSTALLED and not FLASH_ATTN_INSTALLED:
         "reduction order in bf16 differs from a fused kernel by ~1 bf16 "
         "ULP per attention block; compounded across the 80-block stack "
         "this reaches ~O(100) max-diff on the unnormalized residual stream. "
-        "Install xformers (preferred) with `pip install xformers` for a "
-        "fused attention kernel."
+        "Install an xformers build matching your PyTorch and CUDA versions "
+        "for a fused attention kernel."
     )
 
 if torch.cuda.is_available() and not FLASH_ATTN_ROTARY_INSTALLED:

--- a/esm/models/esmc/model.py
+++ b/esm/models/esmc/model.py
@@ -8,7 +8,7 @@ SwiGLU feed-forward networks.
 
 import os
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Self
 
@@ -230,12 +230,14 @@ class EsmcPreTrainedModel(HubPreTrainedModel):
         token: str | None = None,
         local_files_only: bool = False,
         force_download: bool = False,
+        **config_overrides: object,
     ) -> Self:
         """Load an ESMC model from a local directory or the HuggingFace Hub.
 
         ``device`` defaults to CUDA when one is present, and selects the fused
         kernels as well as the placement: they are CUDA-only, so a model built
-        for the CPU must not use them.
+        for the CPU must not use them. Additional keywords override downloaded
+        config fields; unknown fields raise ``TypeError``.
         """
         local_dir = resolve_model_dir(
             pretrained_model_name_or_path,
@@ -246,6 +248,8 @@ class EsmcPreTrainedModel(HubPreTrainedModel):
             force_download=force_download,
         )
         config = cls.config_class.from_pretrained(local_dir)
+        if config_overrides:
+            config = replace(config, **config_overrides)
         if attn_implementation is not None:
             config.attn_implementation = attn_implementation
         if device is None:

--- a/pixi.lock
+++ b/pixi.lock
@@ -165,10 +165,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.48.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - pypi: .
-      - pypi: direct+https://download.pytorch.org/whl/cu130/xformers-0.0.35-py39-none-manylinux_2_28_x86_64.whl
-      - pypi: git+https://github.com/Biohub/transformers.git?rev=main#ef32577f55da19a4989cd7b22e004dc43a4998cb
-      - pypi: git+https://github.com/nrontsis/DockQ.git?rev=ba4df5adaad7c77fd60851d0b7b05f2b77061ba2#ba4df5adaad7c77fd60851d0b7b05f2b77061ba2
       - pypi: https://files.pythonhosted.org/packages/00/78/9cbcc1c073b9d4918e925af1a059762265dc65004e020511b2a06fbfd020/pydssp-0.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/17/66/1ef1960ffa751df4f6ed05a76ba677e331ce451902f319d14c3f8ae81215/rdkit-2026.3.5-cp312-cp312-manylinux_2_28_x86_64.whl
@@ -213,7 +211,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/7e/85/a5bfaebfd305ac18b57b0854d74e37e586809061a91fda62f0bd50c8518e/narwhals-2.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/cd/c607b6337ddcf55cc0249527819b727ef28481d7c56ace54cca69400c2b9/biotraj-1.2.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/81/b6/100d5811cb60bfc13626910cb48872b8ca53f1dcaf2127aac71185575a7f/parallelbar-2.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/5a/7fd1b784a87e96e0078f49a0a13a98b4c5f644ba5597a4a3b70a2ba3e613/py3dmol-2.5.5-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/46/19d3178e70f37fda251f3d9560f29654f09c6eedbe1c8b790adeee84da49/botocore-1.43.75-py3-none-any.whl
@@ -392,9 +389,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-ng-2.3.3-h31dac16_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
       - pypi: .
-      - pypi: git+https://github.com/Biohub/transformers.git?rev=main#ef32577f55da19a4989cd7b22e004dc43a4998cb
-      - pypi: git+https://github.com/nrontsis/DockQ.git?rev=ba4df5adaad7c77fd60851d0b7b05f2b77061ba2#ba4df5adaad7c77fd60851d0b7b05f2b77061ba2
       - pypi: https://files.pythonhosted.org/packages/00/78/9cbcc1c073b9d4918e925af1a059762265dc65004e020511b2a06fbfd020/pydssp-0.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/08/b8/2bc2590a34c733ea0570f366e6ad7d889d05c7825bd3ccab01f36ece71c6/zstd-1.5.7.2-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
@@ -419,7 +415,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/81/b6/100d5811cb60bfc13626910cb48872b8ca53f1dcaf2127aac71185575a7f/parallelbar-2.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/83/b4/fbd2f53d06bd2c98d7f52da05a1d4cc838e4921ca6daa839a30d72d89256/biopython-1.88-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/8c/03/bbc5e9d4aaa2f1c4a942bbeb0c6eff79e56ec370ad8670e029ae6d156489/rdkit-2026.3.5-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
@@ -685,10 +680,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.48.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - pypi: .
-      - pypi: direct+https://download.pytorch.org/whl/cu130/xformers-0.0.35-py39-none-manylinux_2_28_x86_64.whl
-      - pypi: git+https://github.com/Biohub/transformers.git?rev=main#ef32577f55da19a4989cd7b22e004dc43a4998cb
       - pypi: git+https://github.com/nrontsis/DockQ.git?rev=ba4df5adaad7c77fd60851d0b7b05f2b77061ba2#ba4df5adaad7c77fd60851d0b7b05f2b77061ba2
       - pypi: https://files.pythonhosted.org/packages/00/78/9cbcc1c073b9d4918e925af1a059762265dc65004e020511b2a06fbfd020/pydssp-0.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/17/66/1ef1960ffa751df4f6ed05a76ba677e331ce451902f319d14c3f8ae81215/rdkit-2026.3.5-cp312-cp312-manylinux_2_28_x86_64.whl
@@ -939,9 +933,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-ng-2.3.3-h31dac16_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
       - pypi: .
-      - pypi: git+https://github.com/Biohub/transformers.git?rev=main#ef32577f55da19a4989cd7b22e004dc43a4998cb
       - pypi: git+https://github.com/nrontsis/DockQ.git?rev=ba4df5adaad7c77fd60851d0b7b05f2b77061ba2#ba4df5adaad7c77fd60851d0b7b05f2b77061ba2
       - pypi: https://files.pythonhosted.org/packages/00/78/9cbcc1c073b9d4918e925af1a059762265dc65004e020511b2a06fbfd020/pydssp-0.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/08/b8/2bc2590a34c733ea0570f366e6ad7d889d05c7825bd3ccab01f36ece71c6/zstd-1.5.7.2-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
@@ -1230,10 +1224,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.7.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - pypi: .
-      - pypi: direct+https://download.pytorch.org/whl/cu130/xformers-0.0.35-py39-none-manylinux_2_28_x86_64.whl
-      - pypi: git+https://github.com/Biohub/transformers.git?rev=main#ef32577f55da19a4989cd7b22e004dc43a4998cb
       - pypi: git+https://github.com/nrontsis/DockQ.git?rev=ba4df5adaad7c77fd60851d0b7b05f2b77061ba2#ba4df5adaad7c77fd60851d0b7b05f2b77061ba2
       - pypi: https://files.pythonhosted.org/packages/00/78/9cbcc1c073b9d4918e925af1a059762265dc65004e020511b2a06fbfd020/pydssp-0.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1f/88/8dab5de10c638c083772a6be83a3d8106ced492f74a928c8693638e5bb50/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
@@ -1483,9 +1476,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-ng-2.3.3-h31dac16_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
       - pypi: .
-      - pypi: git+https://github.com/Biohub/transformers.git?rev=main#ef32577f55da19a4989cd7b22e004dc43a4998cb
       - pypi: git+https://github.com/nrontsis/DockQ.git?rev=ba4df5adaad7c77fd60851d0b7b05f2b77061ba2#ba4df5adaad7c77fd60851d0b7b05f2b77061ba2
       - pypi: https://files.pythonhosted.org/packages/00/78/9cbcc1c073b9d4918e925af1a059762265dc65004e020511b2a06fbfd020/pydssp-0.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl
@@ -1775,10 +1768,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.7.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - pypi: .
-      - pypi: direct+https://download.pytorch.org/whl/cu130/xformers-0.0.35-py39-none-manylinux_2_28_x86_64.whl
-      - pypi: git+https://github.com/Biohub/transformers.git?rev=main#ef32577f55da19a4989cd7b22e004dc43a4998cb
       - pypi: git+https://github.com/nrontsis/DockQ.git?rev=ba4df5adaad7c77fd60851d0b7b05f2b77061ba2#ba4df5adaad7c77fd60851d0b7b05f2b77061ba2
       - pypi: https://files.pythonhosted.org/packages/00/78/9cbcc1c073b9d4918e925af1a059762265dc65004e020511b2a06fbfd020/pydssp-0.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/07/21/2287edfd0d2569639eea706e25c39e63b46a384cf1712db8ea05768317b0/biotraj-1.2.2.tar.gz
       - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
@@ -2029,9 +2021,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-ng-2.3.3-h31dac16_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
       - pypi: .
-      - pypi: git+https://github.com/Biohub/transformers.git?rev=main#ef32577f55da19a4989cd7b22e004dc43a4998cb
       - pypi: git+https://github.com/nrontsis/DockQ.git?rev=ba4df5adaad7c77fd60851d0b7b05f2b77061ba2#ba4df5adaad7c77fd60851d0b7b05f2b77061ba2
       - pypi: https://files.pythonhosted.org/packages/00/78/9cbcc1c073b9d4918e925af1a059762265dc65004e020511b2a06fbfd020/pydssp-0.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/07/21/2287edfd0d2569639eea706e25c39e63b46a384cf1712db8ea05768317b0/biotraj-1.2.2.tar.gz
       - pypi: https://files.pythonhosted.org/packages/0f/1f/654a3c6364ff0eeca92f140911507497bc8a9a450b3612fc42d889bdc338/rdkit-2026.3.5-cp314-cp314-macosx_11_0_arm64.whl
@@ -2324,9 +2316,9 @@ environments:
       - pypi: .
       - pypi: direct+https://download.pytorch.org/whl/cu130/xformers-0.0.35-py39-none-manylinux_2_28_x86_64.whl
       - pypi: direct+https://github.com/evolutionaryscale/wheels/releases/download/py312-pt211-cu13-sm80-90/flash_attn-2.7.4.post1-cp312-cp312-linux_x86_64.whl
-      - pypi: git+https://github.com/Biohub/transformers.git?rev=main#ef32577f55da19a4989cd7b22e004dc43a4998cb
       - pypi: git+https://github.com/nrontsis/DockQ.git?rev=ba4df5adaad7c77fd60851d0b7b05f2b77061ba2#ba4df5adaad7c77fd60851d0b7b05f2b77061ba2
       - pypi: https://files.pythonhosted.org/packages/00/78/9cbcc1c073b9d4918e925af1a059762265dc65004e020511b2a06fbfd020/pydssp-0.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/17/66/1ef1960ffa751df4f6ed05a76ba677e331ce451902f319d14c3f8ae81215/rdkit-2026.3.5-cp312-cp312-manylinux_2_28_x86_64.whl
@@ -9653,7 +9645,7 @@ packages:
   name: esm
   requires_dist:
   - torch>=2.11.0,<2.12.0
-  - transformers @ git+https://github.com/Biohub/transformers.git@main
+  - transformers>=4.57.6,<5.0.0
   - ipython
   - einops
   - biotite>=1.0.0
@@ -9677,11 +9669,8 @@ packages:
   - pygtrie
   - dna-features-viewer
   - accelerate
-  - dockq @ git+https://github.com/nrontsis/DockQ.git@ba4df5adaad7c77fd60851d0b7b05f2b77061ba2
   - cuequivariance-torch>=0.8.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
   - cuequivariance-ops-torch-cu13>=0.8.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-  - xformers @ https://download.pytorch.org/whl/cu130/xformers-0.0.35-py39-none-manylinux_2_28_x86_64.whl ; platform_machine == 'x86_64' and sys_platform == 'linux'
-  - flash-attn @ https://github.com/evolutionaryscale/wheels/releases/download/py312-pt211-cu13-sm80-90/flash_attn-2.7.4.post1-cp312-cp312-linux_x86_64.whl ; platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'accel'
   requires_python: '>=3.12'
 - pypi: direct+https://download.pytorch.org/whl/cu130/xformers-0.0.35-py39-none-manylinux_2_28_x86_64.whl
   name: xformers
@@ -9697,9 +9686,28 @@ packages:
   - torch
   - einops
   requires_python: '>=3.9'
-- pypi: git+https://github.com/Biohub/transformers.git?rev=main#ef32577f55da19a4989cd7b22e004dc43a4998cb
+- pypi: git+https://github.com/nrontsis/DockQ.git?rev=ba4df5adaad7c77fd60851d0b7b05f2b77061ba2#ba4df5adaad7c77fd60851d0b7b05f2b77061ba2
+  name: dockq
+  version: 2.1.3
+  requires_dist:
+  - numpy>=2.0
+  - biopython>=1.79
+  - networkx
+  - parallelbar
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/00/78/9cbcc1c073b9d4918e925af1a059762265dc65004e020511b2a06fbfd020/pydssp-0.9.1-py3-none-any.whl
+  name: pydssp
+  version: 0.9.1
+  sha256: 74fb8129c07c1625bb687b80f7e94ae7ebf1277725258d7fc75fc1f3d12a67dc
+  requires_dist:
+  - numpy
+  - torch
+  - einops
+  - tqdm
+- pypi: https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl
   name: transformers
   version: 4.57.6
+  sha256: 4c9e9de11333ddfe5114bc872c9f370509198acf0b87a832a0ab9458e2bd0550
   requires_dist:
   - filelock
   - huggingface-hub>=0.34.0,<1.0
@@ -10159,24 +10167,6 @@ packages:
   - opentelemetry-exporter-otlp ; extra == 'open-telemetry'
   - opentelemetry-sdk ; extra == 'open-telemetry'
   requires_python: '>=3.9.0'
-- pypi: git+https://github.com/nrontsis/DockQ.git?rev=ba4df5adaad7c77fd60851d0b7b05f2b77061ba2#ba4df5adaad7c77fd60851d0b7b05f2b77061ba2
-  name: dockq
-  version: 2.1.3
-  requires_dist:
-  - numpy>=2.0
-  - biopython>=1.79
-  - networkx
-  - parallelbar
-  requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/00/78/9cbcc1c073b9d4918e925af1a059762265dc65004e020511b2a06fbfd020/pydssp-0.9.1-py3-none-any.whl
-  name: pydssp
-  version: 0.9.1
-  sha256: 74fb8129c07c1625bb687b80f7e94ae7ebf1277725258d7fc75fc1f3d12a67dc
-  requires_dist:
-  - numpy
-  - torch
-  - einops
-  - tqdm
 - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
   name: h11
   version: 0.16.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 dependencies = [
   "torch>=2.11.0,<2.12.0",
-  "transformers @ git+https://github.com/Biohub/transformers.git@main",
+  "transformers>=4.57.6,<5.0.0",
   "ipython",
   "einops",
   "biotite>=1.0.0",
@@ -51,25 +51,8 @@ dependencies = [
   "pygtrie",
   "dna_features_viewer",
   "accelerate",
-  # Fork adding numpy-2 support on top of upstream v2.1.2. That upstream release
-  # renamed the RMSD keys (iRMSD/LRMSD) and dropped the DockQ_F1 output, which
-  # protein_complex.py recomputes from F1.
-  "dockq @ git+https://github.com/nrontsis/DockQ.git@ba4df5adaad7c77fd60851d0b7b05f2b77061ba2",
   "cuequivariance-torch>=0.8.1; sys_platform == 'linux' and platform_machine == 'x86_64'",
   "cuequivariance-ops-torch-cu13>=0.8.1; sys_platform == 'linux' and platform_machine == 'x86_64'",
-  "xformers @ https://download.pytorch.org/whl/cu130/xformers-0.0.35-py39-none-manylinux_2_28_x86_64.whl ; sys_platform == 'linux' and platform_machine == 'x86_64'",
-]
-
-[project.optional-dependencies]
-# Our own build: PyPI's flash-attn is sdist-only and its setup.py imports torch.
-# transformer-engine is excluded: its core needs a cuBLAS symbol from 13.3, and
-# torch pins cuda-toolkit==13.0.2 which pins nvidia-cublas==13.1.0.3. Get it from
-# the pixi `fused` environment, or by hand:
-#   pip install 'transformer-engine[pytorch]==2.15.0' \
-#     'transformer_engine_torch @ https://github.com/evolutionaryscale/wheels/releases/download/py312-pt211-cu13-sm80-90/transformer_engine_torch-2.15.0-cp312-cp312-linux_x86_64.whl'
-#   pip install --force-reinstall --no-deps 'nvidia-cublas>=13.6'
-accel = [
-  "flash_attn @ https://github.com/evolutionaryscale/wheels/releases/download/py312-pt211-cu13-sm80-90/flash_attn-2.7.4.post1-cp312-cp312-linux_x86_64.whl ; sys_platform == 'linux' and platform_machine == 'x86_64'",
 ]
 # Pytest
 [tool.pytest.ini_options]
@@ -147,6 +130,11 @@ pytest-xdist = "*"
 seaborn = "*"
 ty = "==0.0.49"
 
+[tool.pixi.feature.dev.pypi-dependencies]
+# DockQ is optional at runtime. Keep the NumPy 2-compatible fork in the dev
+# environment for tests without publishing its direct URL in package metadata.
+dockq = { git = "https://github.com/nrontsis/DockQ.git", rev = "ba4df5adaad7c77fd60851d0b7b05f2b77061ba2" }
+
 [tool.pixi.feature.dev.tasks]
 lint-all = "pre-commit run --all-files --show-diff-on-failure"
 cov-test = "pytest -v --junitxml=pytest.xml --cov=esm"
@@ -156,6 +144,7 @@ platforms = ["linux-64"]
 
 [tool.pixi.feature.fused.pypi-dependencies]
 flash_attn = { url = "https://github.com/evolutionaryscale/wheels/releases/download/py312-pt211-cu13-sm80-90/flash_attn-2.7.4.post1-cp312-cp312-linux_x86_64.whl" }
+xformers = { url = "https://download.pytorch.org/whl/cu130/xformers-0.0.35-py39-none-manylinux_2_28_x86_64.whl" }
 cuequivariance-torch = ">=0.8.1"
 cuequivariance-ops-torch-cu13 = ">=0.8.1"
 

--- a/tests/models/esmc_test.py
+++ b/tests/models/esmc_test.py
@@ -730,9 +730,18 @@ def test_a_fresh_classification_head_is_the_only_excused_gap(
     """
     EsmcForMaskedLM(tiny_esmc_config).save_pretrained(tmp_path)
 
-    model = EsmcForSequenceClassification.from_pretrained(tmp_path, device="cpu")
+    model = EsmcForSequenceClassification.from_pretrained(
+        tmp_path, device="cpu", num_labels=7
+    )
+    assert model.num_labels == 7
+    assert model.classifier.out_proj.out_features == 7
     assert not any(p.is_meta for p in model.classifier.parameters())
     assert all(torch.isfinite(p).all() for p in model.classifier.parameters())
+
+    with pytest.raises(TypeError, match="unknown_option"):
+        EsmcForSequenceClassification.from_pretrained(
+            tmp_path, device="cpu", unknown_option=True
+        )
 
     drop_keys(tmp_path, lambda k: k.endswith("embed_tokens.weight"))
     with pytest.raises(RuntimeError, match="missing keys"):


### PR DESCRIPTION
PyPI rejects the wheel's direct URL requirements. This uses the published `transformers` package, keeps optional/dev-only dependencies out of package metadata, and moves the examples onto the native `esm` models; the built wheel has no direct references and the full test suite passes.

🤖 Sent by a robot
